### PR TITLE
feat: expose request.rawBody

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -6,7 +6,7 @@ import { InvalidSignatureError, MissingSignatureError } from './error.js'
 import type { FastifyLineOptions } from './types.js'
 
 const plugin: FastifyPluginCallback<FastifyLineOptions> = (fastify, opts, done) => {
-  if (fastify.line) {
+  if (fastify.hasDecorator('line')) {
     done(new Error('fastify-line plugin has already been registered'))
     return
   }

--- a/src/symbols.ts
+++ b/src/symbols.ts
@@ -1,1 +1,0 @@
-export const kRawBody = Symbol('fastify-line:rawBody')

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,4 @@
 import type { messagingApi } from '@line/bot-sdk'
-import { kRawBody } from './symbols.js'
 
 declare module 'fastify' {
   interface FastifyInstance {
@@ -11,7 +10,12 @@ declare module 'fastify' {
   }
 
   interface FastifyRequest {
-    [kRawBody]: string
+    /**
+     * The raw body of the request.
+     * This is populated when the `lineWebhook` config is set to `true`.
+     * It contains the raw JSON payload sent by LINE.
+     */
+    rawBody?: string
   }
 
   interface FastifyContextConfig {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -3,7 +3,6 @@ import Fastify from 'fastify'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import { InvalidSignatureError, MissingSignatureError } from '../src/error.js'
 import fastifyLine, { type MessageEvent } from '../src/index.js' // Adjust path as needed
-import { kRawBody } from '../src/symbols.js'
 import { kRoutes, printRoutes } from './helpers/print-routes.js'
 
 const DESTINATION = 'Uaaaabbbbccccddddeeeeffff'
@@ -83,6 +82,20 @@ describe('fastifyLine plugin', () => {
       expect(fastify.line).toBeDefined()
       expect(fastify.line).toHaveProperty('pushMessage')
       expect(fastify.line).toHaveProperty('replyMessage')
+    })
+
+    it('should throw error if plugin is registered multiple times', async () => {
+      await fastify.register(fastifyLine, {
+        channelSecret: mockChannelSecret,
+        channelAccessToken: mockChannelAccessToken,
+      })
+
+      await expect(
+        fastify.register(fastifyLine, {
+          channelSecret: mockChannelSecret,
+          channelAccessToken: mockChannelAccessToken,
+        }),
+      ).rejects.toThrow('fastify-line plugin has already been registered')
     })
   })
 
@@ -169,8 +182,8 @@ describe('fastifyLine plugin', () => {
           config: { lineWebhook: true },
         },
         (request) => {
-          rawBody = request[kRawBody]
-          return request[kRawBody]
+          rawBody = request.rawBody
+          return request.rawBody
         },
       )
 
@@ -207,7 +220,7 @@ describe('fastifyLine plugin', () => {
           config: { lineWebhook: true },
         },
         (request) => {
-          rawBody = request[kRawBody]
+          rawBody = request.rawBody
           return {}
         },
       )
@@ -244,7 +257,7 @@ describe('fastifyLine plugin', () => {
           config: { lineWebhook: true },
         },
         (request) => {
-          return request[kRawBody]
+          return request.rawBody
         },
       )
 
@@ -490,7 +503,7 @@ describe('fastifyLine plugin', () => {
           config: { lineWebhook: true },
         },
         (request) => {
-          return request[kRawBody]
+          return request.rawBody
         },
       )
 


### PR DESCRIPTION
close #4 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling to prevent multiple registrations of the plugin on the same server instance.
  * Enhanced reliability of signature validation by ensuring the raw request body is always present.

* **Refactor**
  * Simplified access to the raw request body by replacing symbol-based keys with a direct property (`rawBody`) on the request object.
  * Updated documentation within type definitions for better clarity.

* **Tests**
  * Added a test to verify that duplicate plugin registration triggers an appropriate error.
  * Updated tests to use the new raw body property.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->