### PR TITLE
fix!: support raw-body v4 stream handling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        node-version: [20, 22, 24, 25]
+        node-version: [22, 24, 26]
 
     steps:
       - name: Check out repo

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   "dependencies": {
     "@fastify/error": "^4.2.0",
     "fastify-plugin": "^6.0.0",
-    "raw-body": "^3.0.2"
+    "raw-body": "^4.0.0"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.4.10",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,9 @@
   "bugs": {
     "url": "https://github.com/inyourtime/fastify-line/issues"
   },
+  "engines": {
+    "node": ">=22"
+  },
   "dependencies": {
     "@fastify/error": "^4.2.0",
     "fastify-plugin": "^6.0.0",

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -1,5 +1,11 @@
+import { Readable } from 'node:stream'
 import { LINE_SIGNATURE_HTTP_HEADER_NAME, messagingApi, validateSignature } from '@line/bot-sdk'
-import type { FastifyPluginCallback, preHandlerHookHandler, preParsingHookHandler } from 'fastify'
+import type {
+  FastifyPluginCallback,
+  preHandlerHookHandler,
+  preParsingHookHandler,
+  RequestPayload,
+} from 'fastify'
 import fp from 'fastify-plugin'
 import getRawBody from 'raw-body'
 import { InvalidSignatureError, MissingSignatureError } from './error.js'
@@ -58,23 +64,27 @@ const plugin: FastifyPluginCallback<FastifyLineOptions> = (fastify, opts, done) 
     getRawBody(
       payload,
       {
-        length: null,
+        length: request.headers['content-length'],
         limit: bodyLimit, // avoid memory leak
-        encoding: 'utf8', // ensure the body is a string
       },
-      (err, string) => {
+      (err, buffer) => {
         if (err) {
-          /**
-           * the error is managed by fastify server
-           */
+          done(err)
           return
         }
 
-        request.rawBody = string
+        request.rawBody = buffer.toString('utf8')
+
+        const rawBodyStream: RequestPayload = new Readable({
+          read() {
+            this.push(buffer)
+            this.push(null)
+          },
+        })
+        rawBodyStream.receivedEncodedLength = buffer.length
+        done(null, rawBodyStream)
       },
     )
-
-    done(null, payload)
   }
 
   const verifySignature: preHandlerHookHandler = (request, _reply, done) => {


### PR DESCRIPTION
## Summary

- update `raw-body` to v4
- adjust the LINE webhook `preParsing` hook to wait for `getRawBody` before continuing
- pass Fastify a fresh `Readable` with `receivedEncodedLength` after capturing `request.rawBody`

## Why

`raw-body` v4 is stricter about stream handling and option validation. The old hook consumed the request payload, then immediately returned the original stream to Fastify, which caused webhook requests in tests to hang after the v4 bump.

## Validation

- `npm test`
- `npm run lint`
- `npm run build`